### PR TITLE
Publish path to generated types in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
     "version": "1.0.53",
     "description": "IMAP Client for Node",
     "main": "./lib/imap-flow.js",
+    "types": "./lib/types.d.ts",
     "scripts": {
         "test": "grunt",
         "prepare": "npm run build",


### PR DESCRIPTION
I had problems importing imapflow into my projects because the types were not published properly.
This fix just adds one line to package.json (: